### PR TITLE
fix bug in tidy.glmnet

### DIFF
--- a/R/glmnet_tidiers.R
+++ b/R/glmnet_tidiers.R
@@ -77,7 +77,7 @@ tidy.glmnet <- function(x, ...) {
         }, .id = "class")
         ret <- beta_d %>% tidyr::gather(step, estimate, -term, -class)
     } else {
-        beta_d <- fix_data_frame(as.matrix(beta), newcol = "term")
+        beta_d <- fix_data_frame(as.matrix(beta), newnames=1:ncol(beta), newcol = "term")
         ret <- beta_d %>% tidyr::gather(step, estimate, -term)
     }
     # add values specific to each step


### PR DESCRIPTION
Running the code:

``` R
x <- matrix(rnorm(100*20),100,20)
y <- rnorm(100)
fit1 <- glmnet(x,y) 
head(tidy(fit1))
```

Generates:

```
         term step   estimate lambda dev.ratio
1 (Intercept)   NA -0.2073812     NA        NA
2          V1       NA  0.0000000     NA        NA
3          V2      NA  0.0000000     NA        NA
4          V3      NA  0.0000000     NA        NA
5          V4      NA  0.0000000     NA        NA
6          V5      NA  0.0000000     NA        NA
```

The tidy.glmnet function generates NAs for the step, lambda and dev.ratio columns instead of getting the right values. This fix solves this issue.
